### PR TITLE
Include only built files

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -8,6 +8,9 @@
     "@types/node": "^16.11.6",
     "typescript": "^4.4.4"
   },
+  "files": [
+    "build/*"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Only files compiled with `tsc` should be included in the npm package.